### PR TITLE
Add chattering prevention

### DIFF
--- a/kbduplexmatrix.go
+++ b/kbduplexmatrix.go
@@ -69,8 +69,14 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 			switch d.State[idx] {
 			case None:
 				if current {
-					d.State[idx] = NoneToPress
+					if d.cycleCounter[idx] >= CyclesToPreventChattering {
+						d.State[idx] = NoneToPress
+						d.cycleCounter[idx] = 0
+					} else {
+						d.cycleCounter[idx]++
+					}
 				} else {
+					d.cycleCounter[idx] = 0
 				}
 			case NoneToPress:
 				if current {
@@ -115,8 +121,14 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 			switch d.State[idx] {
 			case None:
 				if current {
-					d.State[idx] = NoneToPress
+					if d.cycleCounter[idx] >= CyclesToPreventChattering {
+						d.State[idx] = NoneToPress
+						d.cycleCounter[idx] = 0
+					} else {
+						d.cycleCounter[idx]++
+					}
 				} else {
+					d.cycleCounter[idx] = 0
 				}
 			case NoneToPress:
 				if current {

--- a/kbduplexmatrix.go
+++ b/kbduplexmatrix.go
@@ -88,8 +88,10 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 					if d.cycleCounter[idx] >= CyclesToPreventChattering {
 						d.State[idx] = PressToRelease
 						d.callback(0, idx, PressToRelease)
+						d.cycleCounter[idx] = 0
+					} else {
+						d.cycleCounter[idx]++
 					}
-					d.cycleCounter[idx]++
 				}
 			case PressToRelease:
 				if current {
@@ -132,8 +134,10 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 					if d.cycleCounter[idx] >= CyclesToPreventChattering {
 						d.State[idx] = PressToRelease
 						d.callback(0, idx, PressToRelease)
+						d.cycleCounter[idx] = 0
+					} else {
+						d.cycleCounter[idx]++
 					}
-					d.cycleCounter[idx]++
 				}
 			case PressToRelease:
 				if current {

--- a/kbduplexmatrix.go
+++ b/kbduplexmatrix.go
@@ -16,7 +16,7 @@ type DuplexMatrixKeyboard struct {
 	cycleCounter []uint8
 }
 
-const CyclesToPreventChattering = uint8(4)
+const duplexMatrixCyclesToPreventChattering = uint8(4)
 
 func (d *Device) AddDuplexMatrixKeyboard(colPins, rowPins []machine.Pin, keys [][]Keycode) *DuplexMatrixKeyboard {
 	col := len(colPins)
@@ -69,7 +69,7 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 			switch d.State[idx] {
 			case None:
 				if current {
-					if d.cycleCounter[idx] >= CyclesToPreventChattering {
+					if d.cycleCounter[idx] >= duplexMatrixCyclesToPreventChattering {
 						d.State[idx] = NoneToPress
 						d.cycleCounter[idx] = 0
 					} else {
@@ -91,7 +91,7 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 				if current {
 					d.cycleCounter[idx] = 0
 				} else {
-					if d.cycleCounter[idx] >= CyclesToPreventChattering {
+					if d.cycleCounter[idx] >= duplexMatrixCyclesToPreventChattering {
 						d.State[idx] = PressToRelease
 						d.callback(0, idx, PressToRelease)
 						d.cycleCounter[idx] = 0
@@ -121,7 +121,7 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 			switch d.State[idx] {
 			case None:
 				if current {
-					if d.cycleCounter[idx] >= CyclesToPreventChattering {
+					if d.cycleCounter[idx] >= duplexMatrixCyclesToPreventChattering {
 						d.State[idx] = NoneToPress
 						d.cycleCounter[idx] = 0
 					} else {
@@ -143,7 +143,7 @@ func (d *DuplexMatrixKeyboard) Get() []State {
 				if current {
 					d.cycleCounter[idx] = 0
 				} else {
-					if d.cycleCounter[idx] >= CyclesToPreventChattering {
+					if d.cycleCounter[idx] >= duplexMatrixCyclesToPreventChattering {
 						d.State[idx] = PressToRelease
 						d.callback(0, idx, PressToRelease)
 						d.cycleCounter[idx] = 0

--- a/keyboard.go
+++ b/keyboard.go
@@ -163,8 +163,6 @@ func (d *Device) Tick() error {
 				if !found {
 					d.pressed = append(d.pressed, x)
 				}
-				// waiting time for chattering prevention
-				time.Sleep(40 * time.Millisecond)
 
 			case Press:
 			case PressToRelease:

--- a/keyboard.go
+++ b/keyboard.go
@@ -163,6 +163,8 @@ func (d *Device) Tick() error {
 				if !found {
 					d.pressed = append(d.pressed, x)
 				}
+				// waiting time for chattering prevention
+				time.Sleep(40 * time.Millisecond)
 
 			case Press:
 			case PressToRelease:


### PR DESCRIPTION
To prevent chattering, a process is added to wait until the key being pressed is released.
However, the wait time is a rough figure. Currently, due to the lack of equipment, it is not possible to see actual voltage changes.
* https://github.com/ehime-iyokan/tinygo-keyboard/commit/ccefd1608e58545ff6f7121ae999f029f2e4e903