### PR TITLE
Add support for vial macros

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -152,7 +152,7 @@ func (d *Device) Tick() error {
 	case <-d.flashCh:
 		d.flashCnt = 1
 	default:
-		if d.flashCnt >= 500 {
+		if d.flashCnt >= 5000 {
 			d.flashCnt = 0
 			err := Save()
 			if err != nil {

--- a/keycodes/keycodes.go
+++ b/keycodes/keycodes.go
@@ -11,6 +11,7 @@ const (
 	TypeMouse    = 0xD000
 	TypeModKey   = 0xFF00
 	TypeToKey    = 0xFF10
+	TypeMacroKey = 0x7700
 )
 
 const (
@@ -39,6 +40,25 @@ const (
 	KeyTo3 = TypeToKey | 0x03
 	KeyTo4 = TypeToKey | 0x04
 	KeyTo5 = TypeToKey | 0x05
+)
+
+const (
+	KeyMacro0  = TypeMacroKey | 0x00
+	KeyMacro1  = TypeMacroKey | 0x01
+	KeyMacro2  = TypeMacroKey | 0x02
+	KeyMacro3  = TypeMacroKey | 0x03
+	KeyMacro4  = TypeMacroKey | 0x04
+	KeyMacro5  = TypeMacroKey | 0x05
+	KeyMacro6  = TypeMacroKey | 0x06
+	KeyMacro7  = TypeMacroKey | 0x07
+	KeyMacro8  = TypeMacroKey | 0x08
+	KeyMacro9  = TypeMacroKey | 0x09
+	KeyMacro10 = TypeMacroKey | 0x0a
+	KeyMacro11 = TypeMacroKey | 0x0b
+	KeyMacro12 = TypeMacroKey | 0x0c
+	KeyMacro13 = TypeMacroKey | 0x0d
+	KeyMacro14 = TypeMacroKey | 0x0e
+	KeyMacro15 = TypeMacroKey | 0x0f
 )
 
 const (


### PR DESCRIPTION
#38

This PR implements the macro functionality for Vial.

https://get.vial.today/manual/macros.html

As shown in the image below, you can use Text, Up, Down, Tap, and Delay.
I'm not sure if it supports everything.
Also, the details might behave slightly differently compared to QMK/Vial.

![image](https://github.com/sago35/tinygo-keyboard/assets/9251039/b3faef3c-0988-4438-9e27-cdfebe827892)
