### PR TITLE
Keycodes

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -490,7 +490,24 @@ func (d *Device) RunMacro(no uint8) error {
 			} else {
 				idx = i + idx
 			}
-			k.Keyboard.Write(macro[i:idx])
+			if keycodes.CharToKeyCodeMap != nil {
+				for _, b := range macro[i:idx] {
+					kc := keycodes.CharToKeyCodeMap[b]
+					switch kc & keycodes.ModKeyMask {
+					case keycodes.TypeNormal:
+						k.Keyboard.Press(kc)
+					case keycodes.TypeNormal | keycodes.ShiftMask:
+						k.Keyboard.Down(keycodes.KeyLeftShift)
+						k.Keyboard.Press(kc ^ keycodes.ShiftMask)
+						k.Keyboard.Up(keycodes.KeyLeftShift)
+					default:
+						//skip
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			} else {
+				k.Keyboard.Write(macro[i:idx])
+			}
 			i = idx
 		}
 	}

--- a/keyboard.go
+++ b/keyboard.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/sago35/tinygo-keyboard/keycodes"
-	"github.com/sago35/tinygo-keyboard/keycodes/jp"
 	"golang.org/x/exp/slices"
 )
 
@@ -549,27 +548,27 @@ func (d *Device) KeyVia(layer, kbIndex, index int) Keycode {
 	}
 	kc := d.kb[kbIndex].Key(layer, index)
 	switch kc {
-	case jp.MouseLeft:
+	case keycodes.MouseLeft:
 		kc = 0x00D1
-	case jp.MouseRight:
+	case keycodes.MouseRight:
 		kc = 0x00D2
-	case jp.MouseMiddle:
+	case keycodes.MouseMiddle:
 		kc = 0x00D3
-	case jp.MouseBack:
+	case keycodes.MouseBack:
 		kc = 0x00D4
-	case jp.MouseForward:
+	case keycodes.MouseForward:
 		kc = 0x00D5
-	case jp.WheelUp:
+	case keycodes.WheelUp:
 		kc = 0x00D9
-	case jp.WheelDown:
+	case keycodes.WheelDown:
 		kc = 0x00DA
-	case jp.KeyMediaBrightnessDown:
+	case keycodes.KeyMediaBrightnessDown:
 		kc = 0x00BE
-	case jp.KeyMediaBrightnessUp:
+	case keycodes.KeyMediaBrightnessUp:
 		kc = 0x00BD
-	case jp.KeyMediaVolumeInc:
+	case keycodes.KeyMediaVolumeInc:
 		kc = 0x00A9
-	case jp.KeyMediaVolumeDec:
+	case keycodes.KeyMediaVolumeDec:
 		kc = 0x00AA
 	case 0xFF10, 0xFF11, 0xFF12, 0xFF13, 0xFF14, 0xFF15:
 		// TO(x)
@@ -612,27 +611,27 @@ func keycodeViaToTGK(key Keycode) Keycode {
 
 	switch key {
 	case 0x00D1:
-		kc = jp.MouseLeft
+		kc = keycodes.MouseLeft
 	case 0x00D2:
-		kc = jp.MouseRight
+		kc = keycodes.MouseRight
 	case 0x00D3:
-		kc = jp.MouseMiddle
+		kc = keycodes.MouseMiddle
 	case 0x00D4:
-		kc = jp.MouseBack
+		kc = keycodes.MouseBack
 	case 0x00D5:
-		kc = jp.MouseForward
+		kc = keycodes.MouseForward
 	case 0x00D9:
-		kc = jp.WheelUp
+		kc = keycodes.WheelUp
 	case 0x00DA:
-		kc = jp.WheelDown
+		kc = keycodes.WheelDown
 	case 0x00BD:
-		kc = jp.KeyMediaBrightnessUp
+		kc = keycodes.KeyMediaBrightnessUp
 	case 0x00BE:
-		kc = jp.KeyMediaBrightnessDown
+		kc = keycodes.KeyMediaBrightnessDown
 	case 0x00A9:
-		kc = jp.KeyMediaVolumeInc
+		kc = keycodes.KeyMediaVolumeInc
 	case 0x00AA:
-		kc = jp.KeyMediaVolumeDec
+		kc = keycodes.KeyMediaVolumeDec
 	case 0x5200, 0x5201, 0x5202, 0x5203, 0x5204, 0x5205:
 		// TO(x)
 		kc = 0xFF10 | (kc & 0x000F)

--- a/keycodes/jp/keycodes.go
+++ b/keycodes/jp/keycodes.go
@@ -1,8 +1,14 @@
 package jp
 
 import (
+	"machine/usb/hid/keyboard"
+
 	"github.com/sago35/tinygo-keyboard/keycodes"
 )
+
+func init() {
+	keycodes.CharToKeyCodeMap = &CharToKeyCodeMap
+}
 
 // for Japanese Keyboard
 // based on machine/usb/hid/keyboard/keycode.go
@@ -176,3 +182,135 @@ const (
 	KeyTo4 = keycodes.KeyTo4
 	KeyTo5 = keycodes.KeyTo5
 )
+
+var CharToKeyCodeMap = [256]keyboard.Keycode{
+	keyboard.ASCII00,
+	keyboard.ASCII01,
+	keyboard.ASCII02,
+	keyboard.ASCII03,
+	keyboard.ASCII04,
+	keyboard.ASCII05,
+	keyboard.ASCII06,
+	keyboard.ASCII07,
+	keyboard.ASCII08,
+	keyboard.ASCII09,
+	keyboard.ASCII0A,
+	keyboard.ASCII0B,
+	keyboard.ASCII0C,
+	keyboard.ASCII0D,
+	keyboard.ASCII0E,
+	keyboard.ASCII0F,
+	keyboard.ASCII10,
+	keyboard.ASCII11,
+	keyboard.ASCII12,
+	keyboard.ASCII13,
+	keyboard.ASCII14,
+	keyboard.ASCII15,
+	keyboard.ASCII16,
+	keyboard.ASCII17,
+	keyboard.ASCII18,
+	keyboard.ASCII19,
+	keyboard.ASCII1A,
+	keyboard.ASCII1B,
+	keyboard.ASCII1C,
+	keyboard.ASCII1D,
+	keyboard.ASCII1E,
+	keyboard.ASCII1F,
+
+	KeySpace,                           //  32   SPACE
+	Key1 | keycodes.ShiftMask,          //  33   !
+	Key2 | keycodes.ShiftMask,          //  34   "
+	Key3 | keycodes.ShiftMask,          //  35   #
+	Key4 | keycodes.ShiftMask,          //  36   $
+	Key5 | keycodes.ShiftMask,          //  37   %
+	Key6 | keycodes.ShiftMask,          //  38   &
+	Key7 | keycodes.ShiftMask,          //  39   '
+	Key8 | keycodes.ShiftMask,          //  40   (
+	Key9 | keycodes.ShiftMask,          //  41   )
+	KeyColon | keycodes.ShiftMask,      //  42   *
+	KeySemicolon | keycodes.ShiftMask,  //  43   +
+	KeyComma,                           //  44   ,
+	KeyMinus,                           //  45   -
+	KeyPeriod,                          //  46   .
+	KeySlash,                           //  47   /
+	Key0,                               //  48   0
+	Key1,                               //  49   1
+	Key2,                               //  50   2
+	Key3,                               //  51   3
+	Key4,                               //  52   4
+	Key5,                               //  53   5
+	Key6,                               //  54   6
+	Key7,                               //  55   7
+	Key8,                               //  55   8
+	Key9,                               //  57   9
+	KeyColon,                           //  58   :
+	KeySemicolon,                       //  59   ;
+	KeyComma | keycodes.ShiftMask,      //  60   <
+	KeyMinus | keycodes.ShiftMask,      //  61   =
+	KeyPeriod | keycodes.ShiftMask,     //  62   >
+	KeySlash | keycodes.ShiftMask,      //  63   ?
+	KeyAt,                              //  64   @
+	KeyA | keycodes.ShiftMask,          //  65   A
+	KeyB | keycodes.ShiftMask,          //  66   B
+	KeyC | keycodes.ShiftMask,          //  67   C
+	KeyD | keycodes.ShiftMask,          //  68   D
+	KeyE | keycodes.ShiftMask,          //  69   E
+	KeyF | keycodes.ShiftMask,          //  70   F
+	KeyG | keycodes.ShiftMask,          //  71   G
+	KeyH | keycodes.ShiftMask,          //  72   H
+	KeyI | keycodes.ShiftMask,          //  73   I
+	KeyJ | keycodes.ShiftMask,          //  74   J
+	KeyK | keycodes.ShiftMask,          //  75   K
+	KeyL | keycodes.ShiftMask,          //  76   L
+	KeyM | keycodes.ShiftMask,          //  77   M
+	KeyN | keycodes.ShiftMask,          //  78   N
+	KeyO | keycodes.ShiftMask,          //  79   O
+	KeyP | keycodes.ShiftMask,          //  80   P
+	KeyQ | keycodes.ShiftMask,          //  81   Q
+	KeyR | keycodes.ShiftMask,          //  82   R
+	KeyS | keycodes.ShiftMask,          //  83   S
+	KeyT | keycodes.ShiftMask,          //  84   T
+	KeyU | keycodes.ShiftMask,          //  85   U
+	KeyV | keycodes.ShiftMask,          //  86   V
+	KeyW | keycodes.ShiftMask,          //  87   W
+	KeyX | keycodes.ShiftMask,          //  88   X
+	KeyY | keycodes.ShiftMask,          //  89   Y
+	KeyZ | keycodes.ShiftMask,          //  90   Z
+	KeyLeftBrace,                       //  91   [
+	KeyBackslash,                       //  92   \
+	KeyRightBrace,                      //  93   ]
+	KeyHat,                             //  94   ^
+	KeyBackslash | keycodes.ShiftMask,  //  95   _
+	KeyAt | keycodes.ShiftMask,         //  96   `
+	KeyA,                               //  97   a
+	KeyB,                               //  98   b
+	KeyC,                               //  99   c
+	KeyD,                               // 100   d
+	KeyE,                               // 101   e
+	KeyF,                               // 102   f
+	KeyG,                               // 103   g
+	KeyH,                               // 104   h
+	KeyI,                               // 105   i
+	KeyJ,                               // 106   j
+	KeyK,                               // 107   k
+	KeyL,                               // 108   l
+	KeyM,                               // 109   m
+	KeyN,                               // 110   n
+	KeyO,                               // 111   o
+	KeyP,                               // 112   p
+	KeyQ,                               // 113   q
+	KeyR,                               // 114   r
+	KeyS,                               // 115   s
+	KeyT,                               // 116   t
+	KeyU,                               // 117   u
+	KeyV,                               // 118   v
+	KeyW,                               // 119   w
+	KeyX,                               // 120   x
+	KeyY,                               // 121   y
+	KeyZ,                               // 122   z
+	KeyLeftBrace | keycodes.ShiftMask,  // 123   {
+	KeyBackslash2 | keycodes.ShiftMask, // 124   |
+	KeyRightBrace | keycodes.ShiftMask, // 125   }
+	KeyHat | keycodes.ShiftMask,        // 126   ~
+	KeyDelete,                          // 127   DEL
+}

--- a/keycodes/jp/keycodes.go
+++ b/keycodes/jp/keycodes.go
@@ -116,9 +116,9 @@ const (
 	KeyF22         = keycodes.TypeNormal | 0x71
 	KeyF23         = keycodes.TypeNormal | 0x72
 	KeyF24         = keycodes.TypeNormal | 0x73
-	KeyBackslash   = keycodes.TypeNormal | 0x87 // \ |
+	KeyBackslash   = keycodes.TypeNormal | 0x87 // \ _
 	KeyHiragana    = keycodes.TypeNormal | 0x88
-	KeyBackslash2  = keycodes.TypeNormal | 0x89 // \ _
+	KeyBackslash2  = keycodes.TypeNormal | 0x89 // \ |
 	KeyHenkan      = keycodes.TypeNormal | 0x8A
 	KeyMuhenkan    = keycodes.TypeNormal | 0x8B
 	KeyKana        = keycodes.TypeNormal | 0x90
@@ -132,33 +132,33 @@ const (
 )
 
 const (
-	KeyMediaBrightnessUp   = keycodes.TypeMediaKey | 0x6F
-	KeyMediaBrightnessDown = keycodes.TypeMediaKey | 0x70
-	KeyMediaPlay           = keycodes.TypeMediaKey | 0xB0
-	KeyMediaPause          = keycodes.TypeMediaKey | 0xB1
-	KeyMediaRecord         = keycodes.TypeMediaKey | 0xB2
-	KeyMediaFastForward    = keycodes.TypeMediaKey | 0xB3
-	KeyMediaRewind         = keycodes.TypeMediaKey | 0xB4
-	KeyMediaNextTrack      = keycodes.TypeMediaKey | 0xB5
-	KeyMediaPrevTrack      = keycodes.TypeMediaKey | 0xB6
-	KeyMediaStop           = keycodes.TypeMediaKey | 0xB7
-	KeyMediaEject          = keycodes.TypeMediaKey | 0xB8
-	KeyMediaRandomPlay     = keycodes.TypeMediaKey | 0xB9
-	KeyMediaPlayPause      = keycodes.TypeMediaKey | 0xCD
-	KeyMediaPlaySkip       = keycodes.TypeMediaKey | 0xCE
-	KeyMediaMute           = keycodes.TypeMediaKey | 0xE2
-	KeyMediaVolumeInc      = keycodes.TypeMediaKey | 0xE9
-	KeyMediaVolumeDec      = keycodes.TypeMediaKey | 0xEA
+	KeyMediaBrightnessUp   = keycodes.KeyMediaBrightnessUp
+	KeyMediaBrightnessDown = keycodes.KeyMediaBrightnessDown
+	KeyMediaPlay           = keycodes.KeyMediaPlay
+	KeyMediaPause          = keycodes.KeyMediaPause
+	KeyMediaRecord         = keycodes.KeyMediaRecord
+	KeyMediaFastForward    = keycodes.KeyMediaFastForward
+	KeyMediaRewind         = keycodes.KeyMediaRewind
+	KeyMediaNextTrack      = keycodes.KeyMediaNextTrack
+	KeyMediaPrevTrack      = keycodes.KeyMediaPrevTrack
+	KeyMediaStop           = keycodes.KeyMediaStop
+	KeyMediaEject          = keycodes.KeyMediaEject
+	KeyMediaRandomPlay     = keycodes.KeyMediaRandomPlay
+	KeyMediaPlayPause      = keycodes.KeyMediaPlayPause
+	KeyMediaPlaySkip       = keycodes.KeyMediaPlaySkip
+	KeyMediaMute           = keycodes.KeyMediaMute
+	KeyMediaVolumeInc      = keycodes.KeyMediaVolumeInc
+	KeyMediaVolumeDec      = keycodes.KeyMediaVolumeDec
 )
 
 const (
-	MouseLeft    = keycodes.TypeMouse | 0x01 // mouse.Left
-	MouseRight   = keycodes.TypeMouse | 0x02 // mouse.Right
-	MouseMiddle  = keycodes.TypeMouse | 0x04 // mouse.Middle
-	MouseBack    = keycodes.TypeMouse | 0x08 // mouse.Back
-	MouseForward = keycodes.TypeMouse | 0x10 // mouse.Forward
-	WheelDown    = keycodes.TypeMouse | 0x20
-	WheelUp      = keycodes.TypeMouse | 0x40
+	MouseLeft    = keycodes.MouseLeft
+	MouseRight   = keycodes.MouseRight
+	MouseMiddle  = keycodes.MouseMiddle
+	MouseBack    = keycodes.MouseBack
+	MouseForward = keycodes.MouseForward
+	WheelDown    = keycodes.WheelDown
+	WheelUp      = keycodes.WheelUp
 )
 
 const (

--- a/keycodes/keycodes.go
+++ b/keycodes/keycodes.go
@@ -1,5 +1,9 @@
 package keycodes
 
+import (
+	"machine/usb/hid/keyboard"
+)
+
 const (
 	ModKeyMask = 0xFF00
 	ToKeyMask  = 0x0010
@@ -66,6 +70,11 @@ const (
 	KeyRestoreDefaultKeymap = 0x7C03
 )
 
+// from machine/usb/hid/keyboard
+const (
+	ShiftMask = 0x0400
+)
+
 const (
 	KeyMediaBrightnessUp   = TypeMediaKey | 0x6F
 	KeyMediaBrightnessDown = TypeMediaKey | 0x70
@@ -94,4 +103,8 @@ const (
 	MouseForward = TypeMouse | 0x10 // mouse.Forward
 	WheelDown    = TypeMouse | 0x20
 	WheelUp      = TypeMouse | 0x40
+)
+
+var (
+	CharToKeyCodeMap *[256]keyboard.Keycode
 )

--- a/keycodes/keycodes.go
+++ b/keycodes/keycodes.go
@@ -65,3 +65,33 @@ const (
 	// restore default keymap for QMK
 	KeyRestoreDefaultKeymap = 0x7C03
 )
+
+const (
+	KeyMediaBrightnessUp   = TypeMediaKey | 0x6F
+	KeyMediaBrightnessDown = TypeMediaKey | 0x70
+	KeyMediaPlay           = TypeMediaKey | 0xB0
+	KeyMediaPause          = TypeMediaKey | 0xB1
+	KeyMediaRecord         = TypeMediaKey | 0xB2
+	KeyMediaFastForward    = TypeMediaKey | 0xB3
+	KeyMediaRewind         = TypeMediaKey | 0xB4
+	KeyMediaNextTrack      = TypeMediaKey | 0xB5
+	KeyMediaPrevTrack      = TypeMediaKey | 0xB6
+	KeyMediaStop           = TypeMediaKey | 0xB7
+	KeyMediaEject          = TypeMediaKey | 0xB8
+	KeyMediaRandomPlay     = TypeMediaKey | 0xB9
+	KeyMediaPlayPause      = TypeMediaKey | 0xCD
+	KeyMediaPlaySkip       = TypeMediaKey | 0xCE
+	KeyMediaMute           = TypeMediaKey | 0xE2
+	KeyMediaVolumeInc      = TypeMediaKey | 0xE9
+	KeyMediaVolumeDec      = TypeMediaKey | 0xEA
+)
+
+const (
+	MouseLeft    = TypeMouse | 0x01 // mouse.Left
+	MouseRight   = TypeMouse | 0x02 // mouse.Right
+	MouseMiddle  = TypeMouse | 0x04 // mouse.Middle
+	MouseBack    = TypeMouse | 0x08 // mouse.Back
+	MouseForward = TypeMouse | 0x10 // mouse.Forward
+	WheelDown    = TypeMouse | 0x20
+	WheelUp      = TypeMouse | 0x40
+)


### PR DESCRIPTION
This PR addresses the following two items:

* Remove the dependency on the keycodes/jp package from sago35/tinygo-keyboard
*  Fix the issue where Macros do not work correctly when using layouts other than US