### PR TITLE
Add implementation for Mod-Tap and Modifier Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The following are supported.
     * [Layers](https://get.vial.today/manual/layers.html) (MO(x), TO(x))
     * Matrix testers
     * [Macros](https://get.vial.today/manual/macros.html)
+    * [Mod-Tap](https://docs.qmk.fm/mod_tap)
+    * [Modifier Keys](https://docs.qmk.fm/feature_advanced_keycodes#modifier-keys)
     * [Combos](https://get.vial.today/manual/combos.html)
 
 ## Microcontrollers

--- a/keycodes/keycodes.go
+++ b/keycodes/keycodes.go
@@ -5,8 +5,10 @@ import (
 )
 
 const (
-	ModKeyMask = 0xFF00
-	ToKeyMask  = 0x0010
+	ModKeyMask      = 0xFF00
+	QuantumMask     = 0xF000
+	QuantumTypeMask = 0x0F00
+	ToKeyMask       = 0x0010
 )
 
 const (
@@ -16,6 +18,26 @@ const (
 	TypeModKey   = 0xFF00
 	TypeToKey    = 0xFF10
 	TypeMacroKey = 0x7700
+	TypeLxxx     = 0x0000
+	TypeRxxx     = 0x1000
+	TypeLxxxT    = 0x2000
+	TypeRxxxT    = 0x3000
+)
+
+const (
+	TypeXCtl = 0x0100
+	TypeXSft = 0x0200
+	TypeXAlt = 0x0400
+	TypeXGui = 0x0800
+
+	TypeLCtlT = TypeLxxxT | TypeXCtl
+	TypeLSftT = TypeLxxxT | TypeXSft
+	TypeLAltT = TypeLxxxT | TypeXAlt
+	TypeLGuiT = TypeLxxxT | TypeXGui
+	TypeRCtlT = TypeRxxxT | TypeXCtl
+	TypeRSftT = TypeRxxxT | TypeXSft
+	TypeRAltT = TypeRxxxT | TypeXAlt
+	TypeRGuiT = TypeRxxxT | TypeXGui
 )
 
 const (


### PR DESCRIPTION
This PR implements the section highlighted by the pink rectangle in the Quantum tab of Vial.

![image](https://github.com/user-attachments/assets/b1bec3f6-a49a-4ec9-bbe7-bb65eab46ac0)
