### PR TITLE
Fix an issue where the `OutputKey` was incorrect when multiple Combos were configured

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -323,7 +323,7 @@ func (d *Device) Tick() error {
 						}
 					}
 				}
-				if matchCnt >= 2 && zero+matchCnt == 4 && matchCnt > matchMax {
+				if matchCnt >= 2 && zero+matchCnt == 4 && matchCnt > matchMax && len(d.combosPressed) == matchCnt {
 					matched = true
 					matchMax = matchCnt
 					d.combosKey = 0xFF000000 | uint32(keycodeViaToTGK(combo[4]))


### PR DESCRIPTION
There was an issue where, if `A + C` and `A + B` were configured, pressing `A + B + C` would mistakenly trigger a Combo.

![image](https://github.com/user-attachments/assets/fc7960e0-55b6-4ffe-b6ad-4f94f941e572)
