### PR TITLE
Fix the press order when cancelling Combos

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -284,10 +284,18 @@ func (d *Device) Tick() error {
 			noneToPress = noneToPress[:0]
 		} else {
 			// Cancel the Combos waiting state if a key unrelated to Combos is pressed.
+			// Sort `d.combosPressed` so that the ones pressed earlier are triggered first.
 			d.combosTimer = time.Time{}
+			ofs := len(noneToPress)
+			noneToPress = d.noneToPressBuf[:ofs+len(d.combosPressed)]
+			for i := range noneToPress[:ofs] {
+				noneToPress[len(noneToPress)-1-i] = noneToPress[ofs-1-i]
+			}
+			idx := 0
 			for xx := range d.combosPressed {
-				noneToPress = append(noneToPress, xx)
+				noneToPress[idx] = xx
 				delete(d.combosPressed, xx)
+				idx++
 			}
 			pressToRelease = append(d.combosReleased, pressToRelease...)
 			d.combosReleased = d.combosReleased[:0]


### PR DESCRIPTION
For example, with the following configuration, if `A` is pressed and then `Z` is pressed within 48ms, the expected behavior is to cancel the Combo and register the keys in the order `A → Z`. However, due to an implementation error, the keys were being registered in the order `Z → A`. This PR fixes this issue.

![image](https://github.com/user-attachments/assets/8322005d-2ab0-45de-b074-502bb62a6755)
