### PR TITLE
board: add build tag for rp2350 so code can be build for xiao-rp2350

### DIFF
--- a/kbrotary.go
+++ b/kbrotary.go
@@ -1,4 +1,4 @@
-//go:build tinygo && (rp2040 || stm32 || k210 || esp32c3 || nrf || (avr && (atmega328p || atmega328pb)))
+//go:build tinygo && (rp2040 || rp2350 || stm32 || k210 || esp32c3 || nrf || (avr && (atmega328p || atmega328pb)))
 
 package keyboard
 


### PR DESCRIPTION
This PR adds the build tag for `rp2350` so code can be build for the `xiao-rp2350` which has just been added as a target in the TinyGo `dev` branch.