### PR TITLE
targets/sg48key, sgh60: fix joystick center drift

### DIFF
--- a/targets/sg48key/adcdevice.go
+++ b/targets/sg48key/adcdevice.go
@@ -62,6 +62,13 @@ func (a *ADCDevice) Get2() int16 {
 
 	ret := int(a.Value)
 	ret += 0x4000
+	// Round to the nearest 2048-wide zone instead of always flooring. Without
+	// this, zone 0 (the dead zone's center bucket) covers only [0, 2047] -
+	// entirely on the positive side of true center - so the negative side of
+	// the dead zone is one zone (2048 counts) narrower than the positive
+	// side, and the stick registers movement much more easily to one side
+	// (observed as a slight drift) than the other.
+	ret += 1024
 	ret >>= 11
 	ret -= 8
 

--- a/targets/sgh60/adcdevice.go
+++ b/targets/sgh60/adcdevice.go
@@ -62,6 +62,13 @@ func (a *ADCDevice) Get2() int16 {
 
 	ret := int(a.Value)
 	ret += 0x4000
+	// Round to the nearest 2048-wide zone instead of always flooring. Without
+	// this, zone 0 (the dead zone's center bucket) covers only [0, 2047] -
+	// entirely on the positive side of true center - so the negative side of
+	// the dead zone is one zone (2048 counts) narrower than the positive
+	// side, and the stick registers movement much more easily to one side
+	// (observed as a slight drift) than the other.
+	ret += 1024
 	ret >>= 11
 	ret -= 8
 


### PR DESCRIPTION
ADCDevice.Get2 assigned the raw value to a 2048-wide zone by flooring, so zone 0 covered only [0, 2047] - entirely on the positive side of true center - and the dead zone extended one zone (2048 counts) further in the positive direction than in the negative one. The stick therefore registered movement much earlier in one direction, observed as a slight drift near center. Add half a zone before shifting so the assignment rounds to the nearest zone and the dead zone becomes symmetric.

Both targets carry the same copy of ADCDevice; confirmed on sg48key hardware.